### PR TITLE
Use cl-generic package

### DIFF
--- a/finalizable.el
+++ b/finalizable.el
@@ -9,6 +9,7 @@
 
 ;;; Code:
 
+(require 'cl-generic)
 (require 'eieio)
 (require 'finalize)
 
@@ -20,10 +21,10 @@
 object. The copy is made after `initialize-instance'.")
   :abstract t)
 
-(defmethod initialize-instance :after ((object finalizable) &key)
+(cl-defmethod initialize-instance :after ((object finalizable) &key)
   (finalize-register object #'finalize (copy-sequence object)))
 
-(defgeneric finalize (object-copy)
+(cl-defgeneric finalize (object-copy)
   "Finalize OBJECT-COPY after it has been garbage collected.
 OBJECT-COPY is a copy made just after `initialize-instance' using
 `copy-sequence'. The object itself is unavailable to this method.")

--- a/finalize-pkg.el
+++ b/finalize-pkg.el
@@ -1,3 +1,3 @@
 (define-package "finalize" "1.0.0"
   "finalizers for Emacs Lisp"
-  '((emacs "24.1") (cl-lib "0.3") (eieio "1.4")))
+  '((emacs "24.1") (cl-generic "0.3") (cl-lib "0.3") (eieio "1.4")))


### PR DESCRIPTION
Like https://github.com/skeeto/emacsql/pull/32, but with the `require` form.

```
Depend on `cl-generic' and use `cl-defgeneric' and `cl-defmethod' that
it defines, instead of `defgeneric' and `defmethod' from the `eieio'
package.

`cl-generic' is part of Emacs since 25.1.  It defines the functions
`cl-defgeneric' and `cl-defmethod', which replace the prefix-less
variants `defgeneric' and `defmethod'.

The latter two are now considered obsolete and to allow authors to
move away from them while maintaining support for older Emacsen, GNU
Elpa features a forward-port of the `cl-generic' package, similar to
what done in the past with `cl-lib'.
```